### PR TITLE
Add keyboard navigation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ set(resource_path "${CMAKE_INSTALL_PREFIX}/etc/arbor-gui")
 add_compile_definitions(ARBORGUI_RESOURCES_BASE="${resource_path}")
 add_compile_definitions(IMGUI_IMPL_OPENGL_LOADER_GL3W="ON")
 
+set(ARB_WITH_NEUROML ON CACHE BOOL "enable neuroml" FORCE)
+
 # figure out OpenGL on *NIX
 if (APPLE)
   find_library(cocoa_library Cocoa)
@@ -58,7 +60,6 @@ set_source_files_properties("${gui_srcs}"
 add_subdirectory("3rd-party/arbor")
 add_subdirectory("3rd-party/glfw")
 
-set(ARB_WITH_NEUROML ON CACHE BOOL "enable neuroml" FORCE)
 
 add_executable(arbor-gui ${gui_srcs} ${im_srcs})
 target_include_directories(arbor-gui PRIVATE 3rd-party/fmt/include)

--- a/src/gui_state.cpp
+++ b/src/gui_state.cpp
@@ -282,6 +282,13 @@ void gui_main(gui_state& state) {
 
     // DockSpace
     ImGuiIO& io = ImGui::GetIO();
+
+    // Swap Space and Enter key bindings
+    // ImGuiKey_Space is used to "activate" menu items,
+    // ImGuiKey_Enter is more intuitive.
+    io.KeyMap[ImGuiKey_Space] = GLFW_KEY_ENTER;
+    io.KeyMap[ImGuiKey_Enter] = GLFW_KEY_SPACE;
+
     if (io.ConfigFlags & ImGuiConfigFlags_DockingEnable) {
         ImGuiID dockspace_id = ImGui::GetID("MyDockSpace");
         ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), dockspace_flags);
@@ -365,7 +372,7 @@ void gui_dir_view(file_chooser_state& state) {
         for (const auto& [dn, path]: dirnames) {
             auto lbl = fmt::format("{} {}", (const char *) ICON_FK_FOLDER, dn);
             ImGui::Selectable(lbl.c_str(), false);
-            if (ImGui::IsItemHovered() && (ImGui::IsMouseDoubleClicked(0) || ImGui::IsKeyPressed(GLFW_KEY_SPACE))) {
+            if (ImGui::IsItemHovered() && (ImGui::IsMouseDoubleClicked(0) || ImGui::IsKeyPressed(GLFW_KEY_ENTER))) {
                 state.cwd = path;
                 state.file.clear();
             }

--- a/src/gui_state.cpp
+++ b/src/gui_state.cpp
@@ -363,13 +363,13 @@ void gui_dir_view(file_chooser_state& state) {
         std::sort(dirnames.begin(), dirnames.end());
 
         for (const auto& [dn, path]: dirnames) {
-                auto lbl = fmt::format("{} {}", (const char *) ICON_FK_FOLDER, dn);
-                ImGui::Selectable(lbl.c_str(), false);
-                if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(0)) {
-                    state.cwd = path;
-                    state.file.clear();
-                }
+            auto lbl = fmt::format("{} {}", (const char *) ICON_FK_FOLDER, dn);
+            ImGui::Selectable(lbl.c_str(), false);
+            if (ImGui::IsItemHovered() && (ImGui::IsMouseDoubleClicked(0) || ImGui::IsKeyPressed(GLFW_KEY_SPACE))) {
+                state.cwd = path;
+                state.file.clear();
             }
+        }
         for (const auto& [fn, path]: filenames) {
             if (ImGui::Selectable(fn.c_str(), path == state.file)) state.file = path;
         }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -39,6 +39,29 @@ static void mouse_callback(GLFWwindow* window, double x, double y) {
     }
 }
 
+void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods)
+{
+    if ((key == GLFW_KEY_DOWN) && (action == GLFW_PRESS)) {
+        delta_y = 15;
+    }
+    if ((key == GLFW_KEY_UP) && (action == GLFW_PRESS)) {
+        delta_y = -15;
+    }
+    if ((key == GLFW_KEY_LEFT) && (action == GLFW_PRESS)) {
+        delta_x = 15;
+    }
+    if ((key == GLFW_KEY_RIGHT) && (action == GLFW_PRESS)) {
+        delta_x = -15;
+    }
+    if ((key == GLFW_KEY_MINUS) && (action == GLFW_PRESS)) {
+        delta_zoom += 2;
+    }
+    if ((key == GLFW_KEY_EQUAL) && (action == GLFW_PRESS)) {
+        delta_zoom -= 2;
+    }
+}
+
+
 bool Window::visible() { return glfwGetWindowAttrib(handle, GLFW_FOCUSED); }
 
 Window::Window() {
@@ -68,15 +91,15 @@ Window::Window() {
     glfwSwapInterval(1); // Enable vsync
     glfwSetScrollCallback(handle, scroll_callback);
     glfwSetCursorPosCallback(handle, mouse_callback);
+    glfwSetKeyCallback(handle, key_callback);
     if (gl3wInit()) log_fatal("Failed to initialize OpenGL loader");
 
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
     ImGuiIO& io = ImGui::GetIO();
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
     if (!(io.ConfigFlags & ImGuiConfigFlags_DockingEnable)) log_error("ImGui docking disabled");
-    //io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
-    //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
 
     ImGui::StyleColorsDark();
     //ImGui::StyleColorsClassic();

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -97,6 +97,8 @@ Window::Window() {
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
     ImGuiIO& io = ImGui::GetIO();
+
+    // Enable keyboard navigation
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
     if (!(io.ConfigFlags & ImGuiConfigFlags_DockingEnable)) log_error("ImGui docking disabled");


### PR DESCRIPTION
- Adds keyboard navigation to select morphology files.
- Adds keyboard navigation to zoom out/in on morphology (-/= keys)
- Adds keyboard navigation to move the morphology left/right/up/down (arrow keys)
- Fixes build