### PR TITLE
desktop file handles icon

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -139,19 +139,6 @@ Window::Window() {
         io.Fonts->AddFontFromFileTTF(path.c_str(), 16.0f, &icons_config, icons_ranges);
     }
     log_debug("Set up fonts");
-
-    #if !__APPLE__
-    log_debug("Setting icon");
-    GLFWimage image;
-    image.pixels = stbi_load((base / "arbor.png").c_str(), &image.width, &image.height, 0, 4); //rgba channels
-    if ((image.width == 0) && (image.height == 0)) log_error("No icon found, are we running after install?");
-    try {
-        glfwSetWindowIcon(handle, 1, &image);
-    } catch(...) {
-        log_warn("Setting icon failed.");
-    }
-    stbi_image_free(image.pixels);
-    #endif
 }
 
 Window::~Window() {


### PR DESCRIPTION
I had deleted this section, but it somehow came back :thinking: 

Since the line that installs `arbor.png` to the requested location did not come back, it segfaults (a check for pixels being NULL did seem to handle this earlier).

The reason I deleted it is that the desktop file seems to handle showing the icon both in DE menus and the window decorator, so this section is doing double work. Maybe you want to have an icon also when not installed, but then you still can't rely on this, as the install instruction that copies  `arbor.png` to the expected location will not have run either. (Suppose that's true for the fonts as well.)