### PR TITLE
ASC file support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ set(resource_path "${CMAKE_INSTALL_PREFIX}/etc/arbor-gui")
 add_compile_definitions(ARBORGUI_RESOURCES_BASE="${resource_path}")
 add_compile_definitions(IMGUI_IMPL_OPENGL_LOADER_GL3W="ON")
 
+# Generate a .json file with full compilation command for each file.
+set(CMAKE_EXPORT_COMPILE_COMMANDS "YES")
+
 # Tweak Arbor
 set(ARB_WITH_NEUROML     ON CACHE BOOL "enable neuroml"    FORCE)
 set(ARB_USE_BUNDLED_LIBS ON CACHE BOOL "use internal deps" FORCE)
@@ -104,7 +107,7 @@ target_include_directories(arbor-gui PRIVATE 3rd-party/imgui/examples)
 target_include_directories(arbor-gui PRIVATE 3rd-party/imgui/examples/libs/gl3w)
 target_include_directories(arbor-gui PRIVATE src)
 target_link_libraries(arbor-gui PRIVATE ${ARBORGUI_LIBS})
-target_link_libraries(arbor-gui PRIVATE arbor arborio arbornml)
+target_link_libraries(arbor-gui PRIVATE arbor arborio)
 target_link_libraries(arbor-gui PRIVATE glfw)
 
 # Set icon on output

--- a/src/definition.hpp
+++ b/src/definition.hpp
@@ -2,7 +2,6 @@
 
 #include <string>
 
-
 #include "utils.hpp"
 
 struct ion_def {

--- a/src/events.hpp
+++ b/src/events.hpp
@@ -3,6 +3,8 @@
 #include <variant>
 
 #include "definition.hpp"
+#include "id.hpp"
+#include "location.hpp"
 
 struct evt_add_ion { std::string name; int charge; };
 struct evt_del_ion { id_type id; };

--- a/src/gui_state.cpp
+++ b/src/gui_state.cpp
@@ -1,6 +1,20 @@
 #include "gui_state.hpp"
 
+#include <arbor/morph/place_pwlin.hpp>
+#include <arbor/morph/mprovider.hpp>
+#include <arbor/morph/primitives.hpp>
+#include <arbor/morph/morphexcept.hpp>
+#include <arbor/morph/label_parse.hpp>
+#include <arbor/morph/region.hpp>
+#include <arbor/morph/locset.hpp>
+#include <arbor/mechcat.hpp>
+#include <arbor/mechinfo.hpp>
+#include <arborio/arbornml.hpp>
+#include <arborio/neurolucida.hpp>
+#include <arborio/swcio.hpp>
+
 #include <imgui.h>
+
 #include <misc/cpp/imgui_stdlib.h>
 
 #include "utils.hpp"
@@ -333,7 +347,7 @@ namespace {
               open_file = false;
             } catch (const arborio::swc_error &e) {
               loader_error = e.what();
-            } catch (const arbnml::neuroml_exception& e) {
+            } catch (const arborio::neuroml_exception& e) {
               loader_error = e.what();
             }
           }

--- a/src/gui_state.hpp
+++ b/src/gui_state.hpp
@@ -1,34 +1,20 @@
 #pragma once
 
 #include <string>
-#include <vector>
-#include <array>
 #include <filesystem>
-#include <variant>
 #include <unordered_set>
 #include <unordered_map>
 
 #include <arbor/cable_cell.hpp>
-#include <arbor/morph/place_pwlin.hpp>
-#include <arbor/morph/mprovider.hpp>
-#include <arbor/morph/primitives.hpp>
-#include <arbor/morph/morphexcept.hpp>
-#include <arbor/morph/label_parse.hpp>
-#include <arbor/morph/region.hpp>
-#include <arbor/morph/locset.hpp>
-#include <arbor/mechcat.hpp>
-#include <arbor/mechinfo.hpp>
 
-#include "view_state.hpp"
-#include "id.hpp"
-#include "component.hpp"
-#include "loader.hpp"
-#include "definition.hpp"
-#include "location.hpp"
-#include "geometry.hpp"
 #include "cell_builder.hpp"
-#include "file_chooser.hpp"
+#include "component.hpp"
+#include "definition.hpp"
 #include "events.hpp"
+#include "file_chooser.hpp"
+#include "geometry.hpp"
+#include "loader.hpp"
+#include "location.hpp"
 
 struct gui_state {
     arb::cable_cell_parameter_set   presets = arb::neuron_parameter_defaults;

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -1,3 +1,13 @@
+#include <vector>
+#include <string>
+#include <tuple>
+#include <filesystem>
+
+#include <arborio/arbornml.hpp>
+#include <arborio/neurolucida.hpp>
+#include <arborio/swcio.hpp>
+#include <arbor/morph/morphology.hpp>
+
 #include "loader.hpp"
 
 namespace io {
@@ -25,7 +35,7 @@ loaded_morphology load_arbor_swc(const std::string &fn) {
 loaded_morphology load_neuroml(const std::filesystem::path &fn) {
     // Read in morph
     auto xml = slurp(fn);
-    arbnml::neuroml nml(xml);
+    arborio::neuroml nml(xml);
     // Extract segment tree
     auto id         = nml.cell_ids().front();
     auto morph_data = nml.cell_morphology(id).value();
@@ -36,7 +46,10 @@ loaded_morphology load_neuroml(const std::filesystem::path &fn) {
 }
 
 loaded_morphology load_asc(const std::filesystem::path &fn) {
-    loaded_morphology result;
+    auto m = arborio::load_asc(fn);
+    loaded_morphology result{.morph=m.morphology};
+    for (const auto &[k, v]: m.labels.regions()) result.regions.emplace_back(k, to_string(v));
+    for (const auto &[k, v]: m.labels.locsets()) result.locsets.emplace_back(k, to_string(v));
     return result;
 }
 

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -40,16 +40,16 @@ loaded_morphology load_neuroml(const std::filesystem::path &fn) {
     auto id         = nml.cell_ids().front();
     auto morph_data = nml.cell_morphology(id).value();
     loaded_morphology result{.morph=morph_data.morphology};
-    for (const auto &[k, v]: morph_data.groups.regions()) result.regions.emplace_back(k, to_string(v));
-    for (const auto &[k, v]: morph_data.groups.locsets()) result.locsets.emplace_back(k, to_string(v));
+    for (const auto& [k, v]: morph_data.groups.regions()) result.regions.emplace_back(k, to_string(v));
+    for (const auto& [k, v]: morph_data.groups.locsets()) result.locsets.emplace_back(k, to_string(v));
     return result;
 }
 
 loaded_morphology load_asc(const std::filesystem::path &fn) {
     auto m = arborio::load_asc(fn);
     loaded_morphology result{.morph=m.morphology};
-    for (const auto &[k, v]: m.labels.regions()) result.regions.emplace_back(k, to_string(v));
-    for (const auto &[k, v]: m.labels.locsets()) result.locsets.emplace_back(k, to_string(v));
+    for (const auto& [k, v]: m.labels.regions()) result.regions.emplace_back(k, to_string(v));
+    for (const auto& [k, v]: m.labels.locsets()) result.locsets.emplace_back(k, to_string(v));
     return result;
 }
 

--- a/src/loader.hpp
+++ b/src/loader.hpp
@@ -5,9 +5,6 @@
 #include <tuple>
 #include <filesystem>
 
-#include <arbornml/arbornml.hpp>
-#include <arbornml/nmlexcept.hpp>
-#include <arborio/swcio.hpp>
 #include <arbor/morph/morphology.hpp>
 
 #include "utils.hpp"
@@ -20,7 +17,7 @@ struct loaded_morphology {
     std::vector<std::pair<std::string, std::string>> locsets;
 };
 
-loaded_morphology load_swc(const std::filesystem::path &fn, std::function<arb::morphology(const std::vector<arborio::swc_record> &)> swc_to_morph);
+//loaded_morphology load_swc(const std::filesystem::path &fn, std::function<arb::morphology(const std::vector<arborio::swc_record> &)> swc_to_morph);
 loaded_morphology load_allen_swc(const std::filesystem::path &fn);
 loaded_morphology load_neuron_swc(const std::filesystem::path &fn);
 loaded_morphology load_arbor_swc(const std::string &fn);
@@ -33,8 +30,8 @@ static std::unordered_map<std::string,
 loaders{{".swc", {{"Arbor",   [](const std::filesystem::path& fn) { return load_arbor_swc(fn); }},
                   {"Allen",   [](const std::filesystem::path& fn) { return load_allen_swc(fn); }},
                   {"Neuron",  [](const std::filesystem::path& fn) { return load_neuron_swc(fn); }}}},
-        {".nml", {{"Default", [](const std::filesystem::path &fn) { return load_neuroml(fn); }}}},
-        {".asc", {{"Default", [](const std::filesystem::path &fn) { return load_asc(fn); }}}}};
+        {".nml", {{"Default", [](const std::filesystem::path& fn) { return load_neuroml(fn); }}}},
+        {".asc", {{"Default", [](const std::filesystem::path& fn) { return load_asc(fn); }}}}};
 
 const std::vector<std::string>& get_suffixes();
 


### PR DESCRIPTION
Add support for Neurolucida ASCII files

* update arbor submodule to the latest version that has support for .asc files
* integrate `arborio::load_asc` into the gui
* a few small fixes to match the new Arbor API
* reduce the number of includes in headers.