### PR TITLE
Improved responsiveness of panning and rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /arbor-gui
 *.ini
 *.kdev4
+build

--- a/src/gui_state.cpp
+++ b/src/gui_state.cpp
@@ -27,6 +27,7 @@ extern float delta_zoom;
 extern float mouse_x;
 extern float mouse_y;
 extern glm::vec2 delta_pos;
+float gui_state_zoom = 0.0f;
 
 namespace {
   inline void gui_read_morphology(gui_state& state, bool& open);
@@ -330,6 +331,7 @@ namespace {
       if (ImGui::IsItemHovered()) {
         state.view.offset -= delta_pos;
         state.view.zoom    = std::clamp(state.view.zoom + delta_zoom, 1.0f, 45.0f);
+        gui_state_zoom     = state.view.zoom;
         state.view.phi     = std::fmod(state.view.phi   + delta_phi   + 2*PI, 2*PI); // cyclic in [0, 2pi)
         state.view.gamma   = std::fmod(state.view.gamma + delta_gamma + 2*PI, 2*PI); // cyclic in [0, 2pi)
       }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -40,11 +40,11 @@ static void mouse_callback(GLFWwindow* window, double x, double y) {
     }
 
     if (lb_down && !ctrl_key) {
-        delta_phi = ((dx > eps) - (dx < eps))*0.1f;
+        delta_phi = 0.05f * dx;
     }
 
     if (mb_down && !ctrl_key) {
-        delta_gamma = ((dy > eps) - (dy < eps))*0.1f;
+        delta_gamma = 0.05f * dy;
     }
 }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1,5 +1,6 @@
 #include "window.hpp"
-
+#include "utils.hpp"
+#include <math.h>
 #include <filesystem>
 
 #define STB_IMAGE_IMPLEMENTATION
@@ -10,10 +11,11 @@ static void glfw_error_callback(int error, const char* description) {
     log_error("Glfw error {}:\n{}", error, description);
 }
 
-float delta_phi     = 0.0f;
-float delta_gamma     = 0.0f;
-float delta_zoom    = 0.0f;
 glm::vec2 delta_pos = {0.0f, 0.0f};
+float delta_phi     = 0.0f;
+float delta_gamma   = 0.0f;
+float delta_zoom    = 0.0f;
+extern float gui_state_zoom;
 
 float mouse_x;
 float mouse_y;
@@ -35,8 +37,8 @@ static void mouse_callback(GLFWwindow* window, double x, double y) {
     auto dy = mouse_y - y; mouse_y = y;
 
     if (lb_down && ctrl_key) {
-        delta_pos.x = (std::abs(dx) > eps) ? -dx*2 : 0.0f;
-        delta_pos.y = (std::abs(dy) > eps) ?  dy*2 : 0.0f;
+        delta_pos.x = - dx * pow(gui_state_zoom, 1.2) / 12;
+        delta_pos.y = dy * pow(gui_state_zoom, 1.2) / 12;
     }
 
     if (lb_down && !ctrl_key) {


### PR DESCRIPTION
Rotation now scales with mouse speed, and panning with zoom level.

Ideally these hardcoded sensitivities could become settings somewhere, for now I tuned them on my machine so that rotation felt good, but this might depend a lot on mouse sensitivity and preference. For the panning I had a better metric, I tuned it so that on all zoom levels the CV markers would stick to the mouse as close as possible during panning.