### PR TITLE
Fix multiple small Issues.

### DIFF
--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -30,7 +30,6 @@ struct renderable {
   size_t    instances = 0;
   unsigned  vao       = 0;
   bool      active    = false;
-  float     scale     = 1.0f;
   float     zorder    = 0.0f;
   glm::vec4 color     = {0.0f, 0.0f, 0.0f, 1.0f};
 };
@@ -78,7 +77,7 @@ struct geometry {
   void make_ruler();
   std::optional<object_id> get_id();
   void clear();
-  void load_geometry(const arb::morphology&);
+  void load_geometry(const arb::morphology&, bool=false);
 
   std::vector<arb::msegment> segments;
   std::vector<point>         vertices;


### PR DESCRIPTION
- Bump arbor version yet again.
- Disable initial CV marker.
- Set minimum rescaling factor to axes size.
- Stop geometry from vanishing after adjusting resolution.
- Clean-up zorder code.